### PR TITLE
Add multi-arch Docker build

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -30,12 +30,13 @@ jobs:
           type=raw,value=latest
           type=sha
     
-    - name: Build and push Docker image
-      uses: docker/build-push-action@v5
-      with:
-        context: .
-        push: true
-        tags: ${{ steps.meta.outputs.tags }}
-        labels: ${{ steps.meta.outputs.labels }}
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/README.md
+++ b/README.md
@@ -60,3 +60,4 @@ export CLAUDE_VOLUME_NAME=my_custom_volume
 - All credentials are stored in Docker volume (configurable via `CLAUDE_VOLUME_NAME`)
 - Login happens inside the container
 - Current directory is mounted as `/workspace` when running Claude Code
+- The GitHub workflow publishes multi-architecture images for `amd64` and `arm64`


### PR DESCRIPTION
## Summary
- build amd64 and arm64 images in GitHub workflow
- document multi-arch image publishing in README

## Testing
- `bash -n setup`
- `bash -n run`
- `bash -n refresh`
- `bash -n clean`
- `ruby -c login_start.rb`
- `ruby -c login_finish.rb`
- `ruby -c refresh_token.rb`


------
https://chatgpt.com/codex/tasks/task_e_684e770e306c832dac609ccc80e6bc7b